### PR TITLE
CARTESIAN_WITH_AUXILIARY_AXES kinematics

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -758,6 +758,10 @@
 //#define COREZY
 //#define MARKFORGED_XY  // MarkForged. See https://reprap.org/forum/read.php?152,504042
 
+// Alternatively, enable the option below for a cartesian machine that has
+// additional auxiliary axes (depending on LINEAR_AXES >= 3) that are not involved in positioning of the main tool
+//#define CARTESIAN_WITH_AUXILILARY_AXES
+
 //===========================================================================
 //============================== Endstop Settings ===========================
 //===========================================================================

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2119,6 +2119,10 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
           #else
             sq(steps_dist_mm.x) + sq(steps_dist_mm.y)
           #endif
+        #elif CARTESIAN_WITH_AUXILILARY_AXES
+          // Axes I, J, K do not contribute to tool positioning. Thus, disregard them, if the three-dimensional XYZ travel distance is longer
+		  // than each of the one-dimensional I, J, K travel distances.
+          _MAX(sq(steps_dist_mm.x) + sq(steps_dist_mm.y) + sq(steps_dist_mm.z), sq(steps_dist_mm.i), sq(steps_dist_mm.j), sq(steps_dist_mm.k))
         #else
           LINEAR_AXIS_GANG(
               sq(steps_dist_mm.x), + sq(steps_dist_mm.y), + sq(steps_dist_mm.z),
@@ -3011,12 +3015,12 @@ bool Planner::buffer_line(const xyze_pos_t &cart, const_feedRate_t fr_mm_s, cons
       const xyze_pos_t cart_dist_mm = LOGICAL_AXIS_ARRAY(
         cart.e - position_cart.e,
         cart.x - position_cart.x, cart.y - position_cart.y, cart.z - position_cart.z,
-        cart.i - position_cart.i, cart.j - position_cart.j, cart.j - position_cart.k
+        cart.i - position_cart.i, cart.j - position_cart.j, cart.k - position_cart.k
       );
     #else
       const xyz_pos_t cart_dist_mm = LINEAR_AXIS_ARRAY(
         cart.x - position_cart.x, cart.y - position_cart.y, cart.z - position_cart.z,
-        cart.i - position_cart.i, cart.j - position_cart.j, cart.j - position_cart.k
+        cart.i - position_cart.i, cart.j - position_cart.j, cart.k - position_cart.k
       );
     #endif
 


### PR DESCRIPTION
### Description

This change should calculate the stepper speeds correctly, according to the set feedrate from the G-code `F` word. 

### Requirements

- index pnp robot 
- enable the newly added option CARTESIAN_WITH_AUXILIARY_AXES
 
### Benefits

Previously, XYZ  stepper speeds were reduced for G1 commands that moved the I, J, and/or K axis.
With this PR, the travel distance used in calculation of stepper movement speeds are calculated as follows:
```
the travel distance is the maximum of (
  XYZ 3D movement distance, 
  I movement distance,
  J movement distance,
  K movement distance,
)
```

### Configurations

use the existing index configurations
and add `#define CARTESIAN_WITH_AUXILIARY_AXES`

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
